### PR TITLE
chore: build with node 20.10.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           version: 8
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.16.1'
+          node-version: '20.10.0'
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Update `release` workflow to use node 20 as version to test and build package