### PR TITLE
docs: npm badge links to npm registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h1 align="center">DiscordBox</h1>
   <p align="center">A Discord Bot framework built on top of <a href="https://discord.js.org/">discord.js</a> that allows you to focus on what makes your bot unique.</p>
 
-![npm](https://img.shields.io/npm/v/discordbox)
+[![npm](https://img.shields.io/npm/v/discordbox)](https://www.npmjs.com/package/discordbox)
 [![CodeFactor](https://www.codefactor.io/repository/github/kibotrel/discordbox/badge?s=1459584c7b64ad6f067146acc6cf10108516a45f)](https://www.codefactor.io/repository/github/kibotrel/discordbox)
 ![GitHub License](https://img.shields.io/github/license/kibotrel/DiscordBox)
 


### PR DESCRIPTION
Add a link to DiscordBox on `npm` so on the related badge for easy navigation