### PR TITLE
fix(types): interactionHandler when action is a slash command

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,7 +43,7 @@ export interface InteractionHandler<
   /**
    * An instance of [SlashCommandBuilder](https://discordjs.guide/slash-commands/response-methods.html#command-response-methods) if the interaction is a command.
    */
-  readonly action: DiscordJS.SlashCommandBuilder | string
+  readonly action: Omit<DiscordJS.SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup"> | string
   readonly callback: (
     interaction: InteractionType,
     metadata?: InteractionMetadata,


### PR DESCRIPTION
When `<InteractionHandler>.action` is a `SlashCommandBuilder` we need to omit some optionnal methods from `discord.js` type.