### PR TITLE
fix(type): 🐛  InteractionHandler.callback

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,10 +49,10 @@ export interface InteractionHandler<
         'addSubcommand' | 'addSubcommandGroup'
       >
     | string
-  readonly callback: (
+  callback(
     interaction: InteractionType,
     metadata?: InteractionMetadata,
-  ) => void | Promise<void>
+  ): void | Promise<void>
 }
 
 export enum LogLevel {


### PR DESCRIPTION
For some reason, type checking won't pass using anonymous function in `InteractionHandler`interface. I found this issue https://github.com/microsoft/TypeScript/pull/18654 regarding the topic that seems to be the cause. Apprently this is a feature.