### PR TITLE
feat(api): millisonds to time string method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
   isObjectOrArray,
   isProductionEnvironment,
   isTestEnvironment,
+  millisecondsToTimeString,
   pluralizeString,
   prettifyArray,
   prettifyObject,

--- a/src/miscs/transform.test.ts
+++ b/src/miscs/transform.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 import {
   capitalizeString,
   humanReadableList,
+  millisecondsToTimeString,
   pluralizeString,
 } from './transform.js'
 
@@ -72,5 +73,56 @@ describe('humanReadableList', () => {
 
   it("should return '' if the list is empty", () => {
     expect(humanReadableList([])).toBe('')
+  })
+})
+
+describe('millisecondsToTimeString', () => {
+  it('should return time in days if input more than a day', () => {
+    expect(millisecondsToTimeString(372_577_688)).toBe('4d 7h 29min 37s 688ms')
+    expect(millisecondsToTimeString(86_400_000)).toBe('1d')
+    expect(millisecondsToTimeString(622_800_000)).toBe('7d 5h')
+    expect(millisecondsToTimeString(608_040_000)).toBe('7d 54min')
+    expect(millisecondsToTimeString(604_812_000)).toBe('7d 12s')
+    expect(millisecondsToTimeString(604_800_123)).toBe('7d 123ms')
+    expect(millisecondsToTimeString(1_000_000_000)).toBe('11d 13h 46min 40s')
+    expect(millisecondsToTimeString(999_960_051)).toBe('11d 13h 46min 51ms')
+    expect(millisecondsToTimeString(997_240_222)).toBe('11d 13h 40s 222ms')
+    expect(millisecondsToTimeString(953_200_981)).toBe('11d 46min 40s 981ms')
+  })
+
+  it('should return time in hours if input is less than a day', () => {
+    expect(millisecondsToTimeString(5_532_532)).toBe('1h 32min 12s 532ms')
+    expect(millisecondsToTimeString(3_600_000)).toBe('1h')
+    expect(millisecondsToTimeString(7_380_000)).toBe('2h 3min')
+    expect(millisecondsToTimeString(3_658_000)).toBe('1h 58s')
+    expect(millisecondsToTimeString(3_600_123)).toBe('1h 123ms')
+    expect(millisecondsToTimeString(64_320_027)).toBe('17h 52min 27ms')
+    expect(millisecondsToTimeString(43_206_271)).toBe('12h 6s 271ms')
+  })
+
+  it('should return time in minutes if input is less than an hour', () => {
+    expect(millisecondsToTimeString(123_456)).toBe('2min 3s 456ms')
+    expect(millisecondsToTimeString(60_000)).toBe('1min')
+    expect(millisecondsToTimeString(247_000)).toBe('4min 7s')
+    expect(millisecondsToTimeString(180_032)).toBe('3min 32ms')
+  })
+
+  it('should return time in seconds if input is less than a minute', () => {
+    expect(millisecondsToTimeString(23_643)).toBe('23s 643ms')
+    expect(millisecondsToTimeString(1000)).toBe('1s')
+  })
+
+  it('should return time in milliseconds if input is less than a second', () => {
+    expect(millisecondsToTimeString(643)).toBe('643ms')
+  })
+
+  it('should return time in milliseconds if input is 0', () => {
+    expect(millisecondsToTimeString(0)).toBe('0ms')
+  })
+
+  it('should throw a RangeError if the input is negative', () => {
+    expect(() => {
+      millisecondsToTimeString(-1)
+    }).toThrow(RangeError)
   })
 })

--- a/src/miscs/transform.ts
+++ b/src/miscs/transform.ts
@@ -1,9 +1,15 @@
 import chalk from 'chalk'
 
+/*
+ * Makes the first letter of a string uppercase and the rest lowercase
+ */
 export const capitalizeString = (string: string) => {
   return string.charAt(0).toUpperCase() + string.slice(1).toLocaleLowerCase()
 }
 
+/*
+ * Handles pluralization of a string based on a count
+ */
 export const pluralizeString = (options: {
   count: number
   singular: string
@@ -67,4 +73,32 @@ export const prettifyObject = (
       return `${key}: ${prettifyVariable(value)}`
     }),
   )
+}
+
+/*
+ * Converts time expressed in milliseconds to a human-readable string
+ */
+export const millisecondsToTimeString = (milliseconds: number) => {
+  if (milliseconds < 0) {
+    throw new RangeError('Time cannot be negative')
+  }
+
+  const steps = [
+    { unit: 'd', divisor: 86_400_000, modulus: 0 },
+    { unit: 'h', divisor: 3_600_000, modulus: 24 },
+    { unit: 'min', divisor: 60_000, modulus: 60 },
+    { unit: 's', divisor: 1000, modulus: 60 },
+    { unit: 'ms', divisor: 1, modulus: 1000 },
+  ]
+  let timeString = ''
+
+  for (const { unit, divisor, modulus } of steps) {
+    const value = modulus
+      ? Math.floor(milliseconds / divisor) % modulus
+      : Math.floor(milliseconds / divisor)
+
+    timeString += value > 0 ? `${value}${unit} ` : ''
+  }
+
+  return timeString.trim() || '0ms'
 }


### PR DESCRIPTION
Utility method that allows you to convert time expressed as milliseconds to a human readable string.

For example: `123456` -> `2min 3s 456ms`