### PR TITLE
feat(api): method to convert snake case to camel case object keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
   isObjectOrArray,
   isProductionEnvironment,
   isTestEnvironment,
+  objectWithCamelCaseKeys,
   pluralizeString,
   prettifyArray,
   prettifyObject,

--- a/src/miscs/index.ts
+++ b/src/miscs/index.ts
@@ -1,5 +1,6 @@
 export * from './checks.js'
 export * from './environments.js'
+export * from './objects.js'
 export * from './strings.js'
 export * from './time.js'
 export * from './transform.js'

--- a/src/miscs/objects.test.ts
+++ b/src/miscs/objects.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { objectWithCamelCaseKeys } from './objects.js'
+
+describe('objectWithCamelCaseKeys', () => {
+  it('should convert snake case keys into camel cases', () => {
+    const snakeCaseObject = {
+      snake_case_key: 'snake_case_value',
+      snake_case_key_2: 'snake_case_value_2',
+    }
+
+    expect(objectWithCamelCaseKeys(snakeCaseObject)).toEqual({
+      snakeCaseKey: 'snake_case_value',
+      snakeCaseKey2: 'snake_case_value_2',
+    })
+  })
+
+  it('should return undefined if the input is undefined', () => {
+    const object = undefined
+
+    expect(objectWithCamelCaseKeys(object)).toEqual(undefined)
+  })
+
+  it('should return undefined if the input is null', () => {
+    /* eslint-disable-next-line unicorn/no-null */
+    const object = null
+
+    expect(objectWithCamelCaseKeys(object)).toEqual(undefined)
+  })
+
+  it('should return empty object if the input is empty object', () => {
+    const object = {}
+
+    expect(objectWithCamelCaseKeys(object)).toEqual({})
+  })
+})

--- a/src/miscs/objects.ts
+++ b/src/miscs/objects.ts
@@ -1,0 +1,21 @@
+/**
+ * Converts an object with snake_case keys to an object with camelCase keys.
+ */
+export const objectWithCamelCaseKeys = <OutputObject>(
+  object: Record<string, unknown> | undefined | null,
+): OutputObject | undefined => {
+  if (!object) {
+    return undefined
+  }
+
+  const entries = Object.entries(object)
+  const camelCaseEntries = entries.map(([key, value]) => {
+    const camelCaseKey = key.replaceAll(/_([\da-z])/g, (_, letter) => {
+      return letter.toUpperCase()
+    })
+
+    return [camelCaseKey, value]
+  })
+
+  return Object.fromEntries(camelCaseEntries)
+}


### PR DESCRIPTION
Because Discord API only accept snake_case property names. It's a bit obnoxious to switch between this and camelCase within a Javascript or Typescript codebase. So this method allows you to get back camelCase keys.